### PR TITLE
knet146 compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,20 +1,14 @@
 name = "Morse"
 uuid = "1ee78b96-f10b-11e8-2f7c-e192173d3e61"
 authors = ["ekinakyurek <akyurekekin@gmail.com>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 AutoGrad = "6710c13c-97f1-543f-91c5-74e8f7d95b35"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Knet = "1902f260-5fb4-5aff-8c31-6271790ab950"
 KnetLayers = "e09e3f5a-3c2e-516c-a806-60ae64389a85"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-
-[compat]
-ArgParse = "0.6.2"
-AutoGrad = "1.2.0"
-Knet = "1.3.0"
-KnetLayers = "0.2.0"
-julia = "1.0.0"

--- a/src/train.jl
+++ b/src/train.jl
@@ -1,4 +1,4 @@
-using Random, AutoGrad, Knet, KnetLayers
+using Random, AutoGrad, Knet, KnetLayers, CUDA
 """
     intro(args)
 
@@ -21,7 +21,7 @@ function intro(args)
         ("--embedSizes"; nargs='+';arg_type=Int; default=[64,256])
             help="char and output embeddings"
         ("--batchSize"; arg_type=Int; default=1; help="batch size for training")
-        ("--atype"; default=(gpu()>=0 ? "KnetArray{Float32}" : "Array{Float32}"))
+        ("--atype"; default=(CUDA.functional() ? "KnetArray{Float32}" : "Array{Float32}"))
         ("--seed"; arg_type=Int; default=31; help="random number seed.")
         ("--previous"; arg_type=Int; default=2; help="output encoder window")
         ("--dropouts"; arg_type=Float64; default= 0.3; help="dropout probabilities")


### PR DESCRIPTION
Added CUDA as dependency and replaced gpu() with CUDA.functional().
The Dropout layer was used with the deprecated `enable` option. I was not sure if changing this was safe so I added back the enable option to KnetLayers in my PR. https://github.com/ekinakyurek/KnetLayers.jl/pull/19